### PR TITLE
Fix concurrent resolution race condition in sync shared / cached factories

### DIFF
--- a/Tests/DependencyInjectionTests/DependencyInjectionTests.swift
+++ b/Tests/DependencyInjectionTests/DependencyInjectionTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 import DependencyInjection
 
@@ -512,21 +513,129 @@ struct DependencyInjectionTests {
             #expect(resolved1 === resolved2)
         }
     }
-    
-    @Test func cachedServicesStartUnique_ThenCache_UntilTheCacheIsReset_resolvedAsync() async {
+
+    @Test func synchronousFactoryCanResolveWithASharedScope_whenResolvedConcurrently() async {
         await withNestedContainer {
             class Super: @unchecked Sendable {
-                init() { }
+                // we're using semaphores here because we need to be able to prevent
+                // the synchronous init from finishing until both Tasks have begun
+                static let semaphore1 = DispatchSemaphore(value: 1)
+                static let semaphore2 = DispatchSemaphore(value: 1)
+
+                init() {
+                    #expect(Self.semaphore1.wait(timeout: .now() + 0.1) == .success)
+                    #expect(Self.semaphore2.wait(timeout: .now() + 0.1) == .success)
+                    Self.semaphore1.signal()
+                    Self.semaphore2.signal()
+                }
+                static let service = Factory(scope: .shared) { Super() }
+            }
+
+            struct Test: Sendable {
+                @Injected(Super.service) var injectedService
+            }
+
+            let test = Test()
+
+            #expect(Super.semaphore1._wait(timeout: .now() + 0.1) == .success)
+            #expect(Super.semaphore2._wait(timeout: .now() + 0.1) == .success)
+            async let _first = Task {
+                Super.semaphore1.signal()
+                return test.injectedService
+            }.value
+            async let _second = Task {
+                Super.semaphore2.signal()
+                return test.injectedService
+            }.value
+            let first = await _first
+            let second = await _second
+
+            #expect(first === second)
+
+            (test.$injectedService.scope as? SharedScope)?.cache.clear()
+
+            #expect(first !== test.injectedService)
+        }
+    }
+
+    @Test func synchronousThrowingFactoryCanResolveWithASharedScope_whenResolvedConcurrently() async throws {
+        try await withNestedContainer {
+            class Super: @unchecked Sendable {
+                // we're using semaphores here because we need to be able to prevent
+                // the synchronous init from finishing until both Tasks have begun
+                static let semaphore1 = DispatchSemaphore(value: 1)
+                static let semaphore2 = DispatchSemaphore(value: 1)
+
+                init() throws {
+                    #expect(Self.semaphore1.wait(timeout: .now() + 0.1) == .success)
+                    #expect(Self.semaphore2.wait(timeout: .now() + 0.1) == .success)
+                    Self.semaphore1.signal()
+                    Self.semaphore2.signal()
+                }
+                static let service = Factory(scope: .shared) { try Super() }
+            }
+
+            struct Test: Sendable {
+                @Injected(Super.service) var injectedService
+            }
+
+            let test = Test()
+
+            #expect(Super.semaphore1._wait(timeout: .now() + 0.1) == .success)
+            #expect(Super.semaphore2._wait(timeout: .now() + 0.1) == .success)
+            async let _first = Task {
+                Super.semaphore1.signal()
+                return test.injectedService
+            }.value
+            async let _second = Task {
+                Super.semaphore2.signal()
+                return test.injectedService
+            }.value
+            let first = try await _first.get()
+            let second = try await _second.get()
+
+            #expect(first === second)
+
+            (test.$injectedService.scope as? SharedScope)?.cache.clear()
+
+            let third = try test.injectedService.get()
+            #expect(first !== third)
+        }
+    }
+
+    @Test func synchronousFactoryCanResolveWithACachedScope_whenResolvedConcurrently() async {
+        await withNestedContainer {
+            class Super: @unchecked Sendable {
+                // we're using semaphores here because we need to be able to prevent
+                // the synchronous init from finishing until both Tasks have begun
+                static let semaphore1 = DispatchSemaphore(value: 1)
+                static let semaphore2 = DispatchSemaphore(value: 1)
+
+                init() {
+                    #expect(Self.semaphore1.wait(timeout: .now() + 0.1) == .success)
+                    #expect(Self.semaphore2.wait(timeout: .now() + 0.1) == .success)
+                    Self.semaphore1.signal()
+                    Self.semaphore2.signal()
+                }
                 static let service = Factory(scope: .cached) { Super() }
             }
+
             struct Test: Sendable {
                 @Injected(Super.service) var injectedService
             }
             
             let test = Test()
-            
-            async let _first = Task { test.injectedService }.value
-            async let _second = Task { test.injectedService }.value
+
+            #expect(Super.semaphore1._wait(timeout: .now() + 0.1) == .success)
+            #expect(Super.semaphore2._wait(timeout: .now() + 0.1) == .success)
+            async let _first = Task {
+                Super.semaphore1.signal()
+                return test.injectedService
+            }.value
+            async let _second = Task {
+                Super.semaphore2.signal()
+                return test.injectedService
+            }.value
             let first = await _first
             let second = await _second
             
@@ -536,5 +645,57 @@ struct DependencyInjectionTests {
             
             #expect(first !== test.injectedService)
         }
+    }
+
+    @Test func synchronousThrowingFactoryCanResolveWithACachedScope_whenResolvedConcurrently() async throws {
+        try await withNestedContainer {
+            class Super: @unchecked Sendable {
+                // we're using semaphores here because we need to be able to prevent
+                // the synchronous init from finishing until both Tasks have begun
+                static let semaphore1 = DispatchSemaphore(value: 1)
+                static let semaphore2 = DispatchSemaphore(value: 1)
+
+                init() throws {
+                    #expect(Self.semaphore1.wait(timeout: .now() + 0.1) == .success)
+                    #expect(Self.semaphore2.wait(timeout: .now() + 0.1) == .success)
+                    Self.semaphore1.signal()
+                    Self.semaphore2.signal()
+                }
+                static let service = Factory(scope: .cached) { try Super() }
+            }
+
+            struct Test: Sendable {
+                @Injected(Super.service) var injectedService
+            }
+
+            let test = Test()
+
+            #expect(Super.semaphore1._wait(timeout: .now() + 0.1) == .success)
+            #expect(Super.semaphore2._wait(timeout: .now() + 0.1) == .success)
+            async let _first = Task {
+                Super.semaphore1.signal()
+                return test.injectedService
+            }.value
+            async let _second = Task {
+                Super.semaphore2.signal()
+                return test.injectedService
+            }.value
+            let first = try await _first.get()
+            let second = try await _second.get()
+
+            #expect(first === second)
+
+            (test.$injectedService.scope as? CachedScope)?.cache.clear()
+
+            let third = try test.injectedService.get()
+            #expect(first !== third)
+        }
+    }
+}
+
+extension DispatchSemaphore {
+    /// Allows us to use `wait` in async code (against better judgement).
+    fileprivate func _wait(timeout: DispatchTime) -> DispatchTimeoutResult {
+        self.wait(timeout: timeout)
     }
 }


### PR DESCRIPTION
## Description

The `SharedScope` and `CachedScope` currently experience a race condition when resolving synchronously and concurrently. This is a tricky condition to create, but here is a summary how this may occur:
1. Factory begins resolution at call site 1
2. Factory simultaneously begins resolution at call site 2 (different context)
3. Both call sites begin resolving a new service instance before either has had the chance to cache the new instance
4. Call site 1 and 2 receive different factory instances (one of which "wins" for caching)

Note: there is no risk of bad access, since the cache itself is thread safe. This is just a logical concurrency error (somewhat similar to the actor reentrancy problem).

I've added a few tests to demonstrate this race condition without a fix in place. I've used a semaphore to block the service init from finishing until I know both tasks that attempt to resolve the factory have actually started. (I used a semaphore, since we need a mechanism capable of blocking in a sync context).

The fix is to lock factory resolution. This is similar to the `@DIActor` isolation and locks used in the `async` resolutions.