### PR TITLE
Add minimum platform requirements for concurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,12 @@ import PackageDescription
 
 let package = Package(
     name: "DependencyInjection",
-    platforms: [.macOS(.v10_15)],
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .watchOS(.v6),
+        .tvOS(.v13),
+    ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(


### PR DESCRIPTION
Add minimum platform requirements to the `Package.swift` going off the minimum required for concurrency.

E.g.
```swift
@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@frozen public struct Task<Success, Failure> : Sendable where Success : Sendable, Failure : Error {
}
```