### PR TITLE
[test-values] - Test defaults are now a thing - TT

### DIFF
--- a/Sources/DependencyInjection/TestContainer.swift
+++ b/Sources/DependencyInjection/TestContainer.swift
@@ -14,7 +14,7 @@ private let _fatalErrorOnResolveRefCount = ManagedAtomic<Int>(0)
 private nonisolated(unsafe) var _originalFatalErrorOnResolveValue: Bool = false
 private let _fatalErrorOnResolveValueSaved = ManagedAtomic<Bool>(false)
 
-public final class TestContainer: Container, @unchecked Sendable {
+final class TestContainer: Container, @unchecked Sendable {
     private let lock = NSRecursiveLock()
     let unregisteredBehavior: UnregisteredBehavior
     let leakedResolutionBehavior: any LeakedResolutionBehavior

--- a/Sources/DependencyInjection/TestDefault.swift
+++ b/Sources/DependencyInjection/TestDefault.swift
@@ -1,0 +1,117 @@
+//
+//  TestDefault.swift
+//  DependencyInjection
+//
+//  Created by Tyler Thompson on 10/18/25.
+//
+
+public struct FactoryDefault: @unchecked Sendable {
+    fileprivate let apply: (Container) -> Void
+    fileprivate init(apply: @escaping (Container) -> Void) { self.apply = apply }
+}
+
+public extension SyncFactory {
+    // Intentionally returns a token; the side effect (register) happens
+    // only when TestDefault/TestDefaults are applied in a test scope.
+    func testValue(_ resolver: @escaping Resolver) -> FactoryDefault {
+        FactoryDefault { [weak self] c in
+            guard let self else { return }
+            (self.scope as? ScopeWithCache)?.cache.clear()
+            c.addResolver(for: self, resolver: resolver)
+        }
+    }
+}
+
+public extension SyncThrowingFactory {
+    // Intentionally returns a token; the side effect (register) happens
+    // only when TestDefault/TestDefaults are applied in a test scope.
+    func testValue(_ resolver: @escaping Resolver) -> FactoryDefault {
+        FactoryDefault { [weak self] c in
+            guard let self else { return }
+            (self.scope as? ScopeWithCache)?.cache.clear()
+            c.addResolver(for: self, resolver: resolver)
+        }
+    }
+}
+
+public extension AsyncFactory {
+    // Intentionally returns a token; the side effect (register) happens
+    // only when TestDefault/TestDefaults are applied in a test scope.
+    func testValue(_ resolver: @escaping Resolver) -> FactoryDefault {
+        FactoryDefault { [weak self] c in
+            guard let self else { return }
+            (self.scope as? ScopeWithCache)?.cache.clear()
+            c.addResolver(for: self, resolver: resolver)
+        }
+    }
+}
+
+public extension AsyncThrowingFactory {
+    // Intentionally returns a token; the side effect (register) happens
+    // only when TestDefault/TestDefaults are applied in a test scope.
+    func testValue(_ resolver: @escaping Resolver) -> FactoryDefault {
+        FactoryDefault { [weak self] c in
+            guard let self else { return }
+            (self.scope as? ScopeWithCache)?.cache.clear()
+            c.addResolver(for: self, resolver: resolver)
+        }
+    }
+}
+
+// MARK: Builders
+
+@resultBuilder
+public enum TestDefaultBuilder {
+    public static func buildBlock(_ parts: [FactoryDefault]...) -> [FactoryDefault] {
+        parts.flatMap { $0 }
+    }
+    public static func buildExpression(_ value: FactoryDefault) -> [FactoryDefault] { [value] }
+    public static func buildOptional(_ component: [FactoryDefault]?) -> [FactoryDefault] { component ?? [] }
+    public static func buildEither(first: [FactoryDefault]) -> [FactoryDefault] { first }
+    public static func buildEither(second: [FactoryDefault]) -> [FactoryDefault] { second }
+}
+
+@resultBuilder
+public enum TestDefaultsBuilder {
+    public static func buildBlock(_ parts: [AnyTestDefaults]...) -> [AnyTestDefaults] {
+        parts.flatMap { $0 }
+    }
+    public static func buildExpression(_ value: TestDefault) -> [AnyTestDefaults] { [value.erase()] }
+    public static func buildExpression(_ value: TestDefaults) -> [AnyTestDefaults] { [value.erase()] }
+    public static func buildOptional(_ component: [AnyTestDefaults]?) -> [AnyTestDefaults] { component ?? [] }
+    public static func buildEither(first: [AnyTestDefaults]) -> [AnyTestDefaults] { first }
+    public static func buildEither(second: [AnyTestDefaults]) -> [AnyTestDefaults] { second }
+}
+
+// MARK: Composable containers
+
+public struct TestDefault: Sendable {
+    fileprivate let items: [FactoryDefault]
+    public init(@TestDefaultBuilder _ make: () -> [FactoryDefault]) { self.items = make() }
+    func apply(to c: Container) { items.forEach { $0.apply(c) } }
+    fileprivate func erase() -> AnyTestDefaults { AnyTestDefaults { self.apply(to: $0) } }
+}
+
+public struct TestDefaults: Sendable {
+    fileprivate let groups: [AnyTestDefaults]
+    public init(@TestDefaultsBuilder _ make: () -> [AnyTestDefaults]) { self.groups = make() }
+    func apply(to c: Container) { groups.forEach { $0.apply(to: c) } }
+    fileprivate func erase() -> AnyTestDefaults { AnyTestDefaults { self.apply(to: $0) } }
+}
+
+public struct AnyTestDefaults: Sendable {
+    fileprivate let _apply: @Sendable (Container) -> Void
+    fileprivate init(_ apply: @Sendable @escaping (Container) -> Void) { self._apply = apply }
+    func apply(to c: Container) { _apply(c) }
+}
+
+// MARK: Entry point
+//
+//public func withTestContainer<T>(defaults: TestDefaults,
+//                                 _ body: @escaping () throws -> T) rethrows -> T {
+//    try withTestContainer {
+//        var c = Container.current
+//        defaults.apply(to: c)          // <-- deferred execution happens here
+//        return try body()
+//    }
+//}

--- a/Sources/DependencyInjection/TestDefault.swift
+++ b/Sources/DependencyInjection/TestDefault.swift
@@ -104,14 +104,3 @@ public struct AnyTestDefaults: Sendable {
     fileprivate init(_ apply: @Sendable @escaping (Container) -> Void) { self._apply = apply }
     func apply(to c: Container) { _apply(c) }
 }
-
-// MARK: Entry point
-//
-//public func withTestContainer<T>(defaults: TestDefaults,
-//                                 _ body: @escaping () throws -> T) rethrows -> T {
-//    try withTestContainer {
-//        var c = Container.current
-//        defaults.apply(to: c)          // <-- deferred execution happens here
-//        return try body()
-//    }
-//}

--- a/Sources/DependencyInjection/TestDefault.swift
+++ b/Sources/DependencyInjection/TestDefault.swift
@@ -92,7 +92,11 @@ public struct TestDefault: Sendable {
     fileprivate func erase() -> AnyTestDefaults { AnyTestDefaults { self.apply(to: $0) } }
 }
 
-public struct TestDefaults: Sendable {
+public struct TestDefaults: Sendable, ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: TestDefaults...) {
+        self.groups = elements.map { $0.erase() }
+    }
+    
     fileprivate let groups: [AnyTestDefaults]
     public init(@TestDefaultsBuilder _ make: () -> [AnyTestDefaults]) { self.groups = make() }
     func apply(to c: Container) { groups.forEach { $0.apply(to: c) } }

--- a/Tests/DependencyInjectionTests/InjectedPropertyWrapperTests.swift
+++ b/Tests/DependencyInjectionTests/InjectedPropertyWrapperTests.swift
@@ -98,7 +98,7 @@ struct InjectedPropertyWrapperTests {
             let example = Example()
             #expect(try await example.dependency.value === expected)
             #expect(try await example.dependency.value === expected)
-            #expect(try await test.count == 2)
+            #expect(await test.count == 2)
         }
     }
     

--- a/Tests/DependencyInjectionTests/InjectedPropertyWrapperTests.swift
+++ b/Tests/DependencyInjectionTests/InjectedPropertyWrapperTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Testing
+import Atomics
 import DependencyInjection
 import DependencyInjectionMacros
 
@@ -17,15 +18,15 @@ struct InjectedPropertyWrapperTests {
         
         withTestContainer {
             let expected = ExampleDependency()
-            var count = 0
+            let count = ManagedAtomic(0)
             Container.exampleDependency.register {
-                count += 1
+                count.wrappingIncrement(ordering: .sequentiallyConsistent)
                 return expected
             }
             let example = Example()
             #expect(example.dependency === expected)
             #expect(example.dependency === expected)
-            #expect(count == 2)
+            #expect(count.load(ordering: .sequentiallyConsistent) == 2)
         }
     }
     
@@ -37,15 +38,15 @@ struct InjectedPropertyWrapperTests {
         try withTestContainer {
             let expectedResult = Result { try ExampleThrowingDependency() }
             let expected = try expectedResult.get()
-            var count = 0
+            let count = ManagedAtomic(0)
             Container.exampleThrowingDependency.register {
-                count += 1
+                count.wrappingIncrement(ordering: .sequentiallyConsistent)
                 return try expectedResult.get()
             }
             let example = Example()
             #expect(try example.dependency.get() === expected)
             #expect(try example.dependency.get() === expected)
-            #expect(count == 2)
+            #expect(count.load(ordering: .sequentiallyConsistent) == 2)
         }
     }
     
@@ -108,14 +109,14 @@ struct InjectedPropertyWrapperTests {
         
         withTestContainer {
             let expected = ExampleDependency()
-            var count = 0
+            let count = ManagedAtomic(0)
             Container.exampleDependency.register {
-                count += 1
+                count.wrappingIncrement(ordering: .sequentiallyConsistent)
                 return expected
             }
             #expect(Example.dependency === expected)
             #expect(Example.dependency === expected)
-            #expect(count == 2)
+            #expect(count.load(ordering: .sequentiallyConsistent) == 2)
         }
     }
 }

--- a/Tests/DependencyInjectionTests/TestContainerTests.swift
+++ b/Tests/DependencyInjectionTests/TestContainerTests.swift
@@ -369,10 +369,10 @@ struct TestContainerTests {
     @Test func withNestedContainer_InsideTestContainer_PreservesLeakDetection() async throws {
         let factory = Factory { true }
         
-        await withTestContainer(unregisteredBehavior: failTestBehavior,
+        withTestContainer(unregisteredBehavior: failTestBehavior,
                                leakedResolutionBehavior: BestEffortLeakedResolutionBehavior()) {
             // This should trigger leak detection through the nested container
-            await withNestedContainer {
+            withNestedContainer {
                 // Register the factory in THIS nested container - TestContainers are isolated
                 factory.register { true }
                 // This will cause a leak that should be handled gracefully
@@ -400,8 +400,8 @@ struct TestContainerTests {
     @Test func withTestContainer_InsideNestedContainer_PreservesLeakDetection() async throws {
         let factory = Factory { true }
         
-        await withNestedContainer {
-            await withTestContainer(unregisteredBehavior: failTestBehavior,
+        withNestedContainer {
+            withTestContainer(unregisteredBehavior: failTestBehavior,
                                leakedResolutionBehavior: BestEffortLeakedResolutionBehavior()) {
                 // This should trigger leak detection through the nested container
                 // Register the factory in THIS nested container - TestContainers are isolated
@@ -417,7 +417,7 @@ struct TestContainerTests {
         withKnownIssue {
             withTestContainer(unregisteredBehavior: failTestBehavior) {
                 withNestedContainer {
-                    factory() // this should fail
+                    _ = factory() // this should fail
                     return
                 }
             }
@@ -603,6 +603,12 @@ struct TestContainerTests {
     
     @Test func testContainerHasComposableDefaults() async throws {
         withTestContainer(defaults: .myFeatureDefaults) {
+            #expect(Container.prodService() is NoopProdService) // does not crash
+        }
+    }
+    
+    @Test func testContainerHasMultipleDefaults() async throws {
+        withTestContainer(defaults: [.libraryDefaults, .myFeatureDefaults]) {
             #expect(Container.prodService() is NoopProdService) // does not crash
         }
     }


### PR DESCRIPTION
### Problem statement:
Previously, every test container required explicit registration of all dependencies, even ubiquitous or non-critical ones such as logging, metrics, or feature flags. While that enforced rigor, it added cognitive load and friction for feature authors, who frequently had to redefine obvious defaults.

The new system allows library authors to supply their own reusable, composable test defaults while keeping test behavior explicit and predictable. There is no implicit trust — tests must still opt in to any defaults they wish to apply. While I know @danibachar disagrees with that approach, I believe explicitness is key to good architecture. Additionally, if people want implicit behaviors, they can take explicit ones and easily make them implicit, the same can't be said the other way around. To be clear, what I mean is that consumers could easily define their own `withTestContainer` function that supplied all the defaults. 

However, it's worth noting that with the deferred design (which I believe is ALSO critical, since deferring execution is generally a good idea) this is basically a necessity. 

### The design
Let's say the library author wants to create their own reasonable defaults:
```swift
// library target
protocol ProdService { }

struct _ProdService: ProdService { }
extension Container {
    static let prodService = Factory { _ProdService() as ProdService }
}

// library mocks target
struct NoopProdService: ProdService { }

extension TestDefaults {
    static let libraryDefaults = TestDefaults { // all test defaults I want to expose
        prodServiceTestDefault
    }
    
    // specific ones I compose into it for flexibility
    static let prodServiceTestDefault = TestDefault { Container.prodService.testValue { NoopProdService() } }
}
```

Now the consumers wants to make use of this, there are 3 choices that are reasonable:
```swift
// first choice, define specific ones you want to default
withTestContainer(defaults: .libraryDefaults) {
    #expect(Container.prodService() is NoopProdService) // does not crash
}

// second choice, make feature-wide defaults you always want
extension TestDefaults {
    static let myFeatureDefaults = TestDefaults {
        .libraryDefaults // all defaults from the library
        prodServiceTestDefault // just this single one, this could be from anywhere
        TestDefault { Container.prodService.testValue { NoopProdService() } } // even if the library author didn't define it
    }
}

withTestContainer(defaults: .myFeatureDefaults) {
    #expect(Container.prodService() is NoopProdService) // does not crash
}

// third choice, make this implicit, shadow the function
@discardableResult
func withTestContainer<T>(unregisteredBehavior: UnregisteredBehavior = .fatalError,
                           leakedResolutionBehavior: any LeakedResolutionBehavior = DefaultLeakedResolutionBehavior(),
                           file: String = #file, line: UInt = #line, function: String = #function,
                           operation: () throws -> T) rethrows -> T {
    withTestContainer(defaults: .myFeatureDefaults, unregisteredBehavior: unregisteredBehavior, leakedResolutionBehavior: leakedResolutionBehavior, file: file, line: line, function: function, operation: operation)
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional defaults parameter to test container helpers for per-test configuration.
  * Introduced a composable test defaults framework to build reusable, structured test setups and swap implementations.
  * Added lightweight test dependency primitives and reusable default groups for easier test wiring.

* **Tests**
  * Added tests covering optional, composable, and multiple defaults scenarios.
  * Replaced plain integer counters with atomic operations for thread-safe, reliable assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->